### PR TITLE
Cast client id and client secret to string PHP8.2 compatibility

### DIFF
--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -89,19 +89,19 @@ class Config extends \Magento\Payment\Gateway\Config\Config
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getClientId()
     {
-        return $this->getValue('client_id');
+        return (string)$this->getValue('client_id');
     }
 
     /**
-     * @return mixed
+     * @return string
      */
     public function getClientSecret()
     {
-        return $this->getValue('client_secret');
+        return (string)$this->getValue('client_secret');
     }
 
     /**

--- a/Gateway/Config/Config.php
+++ b/Gateway/Config/Config.php
@@ -87,7 +87,7 @@ class Config extends \Magento\Payment\Gateway\Config\Config
      */
     public function getClientId()
     {
-        return (string)$this->getValue('client_id');
+        return (string) $this->getValue('client_id');
     }
 
     /**
@@ -95,7 +95,7 @@ class Config extends \Magento\Payment\Gateway\Config\Config
      */
     public function getClientSecret()
     {
-        return (string)$this->getValue('client_secret');
+        return (string) $this->getValue('client_secret');
     }
 
     public function getSignature()


### PR DESCRIPTION
There is a problem while initialization vendor/getkevin/kevin-php/src/UtilityTrait.php in line 389:
` if (!strlen($this->clientId) || !strlen($this->clientSecret)) {`
clientId is null, but strlen method requires a string.
![Screenshot-2024-01-19-at-10-20-12](https://github.com/getkevin/kevin-magento2/assets/11822697/ca114a31-2cf6-455a-9e30-bd305b8698ad)
